### PR TITLE
Parts bidirectionality and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ The configurator can receive the following parameters:
 | sensitivity             | `Number`   | `false`  | Configurator rotation sensitivity to the user mouse drag action. The bigger the number, more sensible it is.                                                       |
 | useMasks                | `Boolean`  | `false`  | Usage of masks in the current model, necessary for the part highlighting action.                                                                                   |
 | duration                | `Number`   | `false`  | The duration in milliseconds that the configurator frame transition should take.                                                                                   |
-| animation           | `String`   | `false`  | The configurator animation style: 'simple' (fade in), 'cross' (crossfade) or 'null'.                                                                               |
+| animation               | `String`   | `false`  | The configurator animation style: 'simple' (fade in), 'cross' (crossfade) or 'null'.                                                                               |
 | format                  | `String`   | `false`  | The format of the configurator image, (eg: png, jpg, svg, etc.).                                                                                                   |
 | ripe                    | `Number`   | `false`  | Instance of Ripe SDK initialized, if not defined, the global Ripe SDK instance will be used.                                                                       |
 | onUpdateFrame           | `Function` | `false`  | Callback called when the frame in the configurator is changed.                                                                                                     |
+| onUpdateParts           | `Function` | `false`  | Callback called when the parts of the model are changed. This can be due to restrictions and rules of the model when applying a certain customization.             |
 | onUpdateSelectedPart    | `Function` | `false`  | Callback when a part of the model in the configurator is selected.                                                                                                 |
 | onUpdateHighlightedPart | `Function` | `false`  | Callback when a part of the model in the configurator is highlighted, normally with a mouse hover of by changing the prop. Only functional when masks are enabled. |
 | onLoading               | `Function` | `false`  | Callback called when the configurator is loading.                                                                                                                  |
@@ -40,6 +41,7 @@ An example of an instantiation and the correspondent view:
     version={52}
     size={1000}
     onUpdateFrame={frame => {}}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -57,6 +59,7 @@ The frame can be controlled externally to the component, by changing the prop `f
     size={1000}
     frame={"top-0"}
     onUpdateFrame={frame => {}}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -91,6 +94,7 @@ The customization of the model can also be provided, with the prop `parts`:
         }
     }}
     onUpdateFrame={frame => {}}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -116,6 +120,7 @@ It is also possible to define the highlighted part of the configurator, which wi
     animation={"cross"}
     format={"png"}
     onUpdateFrame={frame => {}}
+    onUpdateParts={parts => {}}
     onUpdateSelectedPart={part => {}}
     onUpdateHighlightedPart={part => {}}
     onLoading={() => {}}
@@ -135,6 +140,7 @@ There can be more than one configurator using the same instance of Ripe SDK:
     size={500}
     ripe={this.ripe}
     onUpdateFrame={frame => {}}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -146,6 +152,7 @@ There can be more than one configurator using the same instance of Ripe SDK:
     frame={"side-10"}
     ripe={this.ripe}
     onUpdateFrame={frame => {}}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -183,6 +190,7 @@ The image can receive the following parameters:
 | initialsBuilder | `Function` | `false`  | A function that receives the initials and engraving as strings and the img element that will be used and returns a map with the initials and a profile list.                                               |
 | state           | `Object`   | `false`  | An object containing the state of the personalization. For each group of the model it can contain the initials and the corresponding engraving (eg. { main: { initials: "AB", engraving: "style:grey" }}). |
 | ripe            | `Number`   | `false`  | Instance of Ripe SDK initialized, if not defined, the global Ripe SDK instance will be used.                                                                                                               |
+| onUpdateParts   | `Function` | `false`  | Callback called when the parts of the model are changed. This can be due to restrictions and rules of the model when applying a certain customization.                                                     |
 | onLoading       | `Function` | `false`  | Callback called when the configurator is loading.                                                                                                                                                          |
 | onLoaded        | `Function` | `false`  | Callback called when the configurator has loaded.                                                                                                                                                          |
 
@@ -194,6 +202,7 @@ An example of an instantiation and the correspondent view:
     model={"cube"}
     version={52}
     size={500}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -210,6 +219,7 @@ Similar to the configurator, the frame can be controlled externally to the compo
     version={52}
     size={1000}
     frame={"top-0"}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -243,6 +253,7 @@ The customization of the model can also be provided, with the `prop` parts:
             material: "leather_cbe"
         }
     }}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -294,6 +305,7 @@ There can be more than one image using the same instance of Ripe SDK:
     version={52}
     size={500}
     ripe={this.ripe}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -304,6 +316,7 @@ There can be more than one image using the same instance of Ripe SDK:
     size={500}
     frame={"side-10"}
     ripe={this.ripe}
+    onUpdateParts={parts => {}}
     onLoading={() => {}}
     onLoaded={() => {}}
 />
@@ -361,17 +374,18 @@ The price component allows for the visualization of the price of a model, accord
 
 The price can receive the following parameters:
 
-| Prop          | Type       | Required | Description                                                                                                                |
-| ------------- | ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| brand         | `String`   | `true`   | The brand of the model.                                                                                                    |
-| model         | `String`   | `true`   | The name of the model.                                                                                                     |
-| version       | `Number`   | `true`   | The version of the build.                                                                                                  |
-| parts         | `Object`   | `false`  | The model's customization.                                                                                                 |
-| currency      | `String`   | `true`   | The `ISO 4217` currency code in which the price will be displayed.                                                         |
-| ripe          | `Number`   | `false`  | Instance of Ripe SDK initialized, if not defined, the global Ripe SDK instance will be used.                               |
-| onUpdatePrice | `Function` | `false`  | Callback when the price of the model changes. It can be triggered when the currency is changed or the model and its parts. |
-| onLoading     | `Function` | `false`  | Callback called when the configurator is loading.                                                                          |
-| onLoaded      | `Function` | `false`  | Callback called when the configurator has loaded.                                                                          |
+| Prop          | Type       | Required | Description                                                                                                                                            |
+| ------------- | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| brand         | `String`   | `true`   | The brand of the model.                                                                                                                                |
+| model         | `String`   | `true`   | The name of the model.                                                                                                                                 |
+| version       | `Number`   | `true`   | The version of the build.                                                                                                                              |
+| parts         | `Object`   | `false`  | The model's customization.                                                                                                                             |
+| currency      | `String`   | `true`   | The `ISO 4217` currency code in which the price will be displayed.                                                                                     |
+| ripe          | `Number`   | `false`  | Instance of Ripe SDK initialized, if not defined, the global Ripe SDK instance will be used.                                                           |
+| onUpdateParts | `Function` | `false`  | Callback called when the parts of the model are changed. This can be due to restrictions and rules of the model when applying a certain customization. |
+| onUpdatePrice | `Function` | `false`  | Callback when the price of the model changes. It can be triggered when the currency is changed or the model and its parts.                             |
+| onLoading     | `Function` | `false`  | Callback called when the configurator is loading.                                                                                                      |
+| onLoaded      | `Function` | `false`  | Callback called when the configurator has loaded.                                                                                                      |
 
 An example of an instantiation and the correspondent view:
 

--- a/react/components/organisms/ripe-configurator/ripe-configurator.js
+++ b/react/components/organisms/ripe-configurator/ripe-configurator.js
@@ -193,6 +193,7 @@ export class RipeConfigurator extends mix(Component).with(LogicMixin) {
         });
 
         this.state.ripeData.bind("parts", parts => {
+            if (this._equalParts(parts, this.state.partsData)) return;
             this.setState({ partsData: parts }, () => this.props.onUpdateParts(parts));
         });
 

--- a/react/components/organisms/ripe-configurator/ripe-configurator.js
+++ b/react/components/organisms/ripe-configurator/ripe-configurator.js
@@ -313,8 +313,8 @@ export class RipeConfigurator extends mix(Component).with(LogicMixin) {
                 partsData: parts
             },
             async () => {
-                this.props.onUpdateParts(parts);
-                await this._configRipe();
+                await this.props.onUpdateParts(parts);
+                await this._setPartsRipe(parts);
             }
         );
     }

--- a/react/components/organisms/ripe-configurator/ripe-configurator.js
+++ b/react/components/organisms/ripe-configurator/ripe-configurator.js
@@ -1,13 +1,15 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Ripe, ripe } from "ripe-sdk";
+import { ripe } from "ripe-sdk";
+import { mix } from "yonius";
 
+import { LogicMixin } from "../../../mixins";
 import { Loader } from "../../atoms";
 
 import "ripe-sdk/src/css/ripe.css";
 import "./ripe-configurator.css";
 
-export class RipeConfigurator extends Component {
+export class RipeConfigurator extends mix(Component).with(LogicMixin) {
     static get propTypes() {
         return {
             /**
@@ -86,6 +88,12 @@ export class RipeConfigurator extends Component {
              */
             onUpdateFrame: PropTypes.func,
             /**
+             * Callback called when the parts of the model are changed. This
+             * can be due to restrictions and rules of the model when applying
+             * a certain customization.
+             */
+            onUpdateParts: PropTypes.func,
+            /**
              * Callback when a part of the model in the configurator is selected.
              */
             onUpdateSelectedPart: PropTypes.func,
@@ -125,6 +133,7 @@ export class RipeConfigurator extends Component {
             format: null,
             ripe: null,
             onUpdateFrame: frame => {},
+            onUpdateParts: parts => {},
             onUpdateSelectedPart: part => {},
             onUpdateHighlightedPart: part => {},
             onLoading: () => {},
@@ -171,6 +180,22 @@ export class RipeConfigurator extends Component {
 
         await this._setupRipe();
 
+        // saves the model parts after the RIPE configuration so that
+        // possible changes due to restrictions can be communicated
+        // to the parent component
+        this.setState({ partsData: Object.assign({}, this.state.ripeData.parts) }, () =>
+            this.props.onUpdateParts(this.state.ripeData.parts)
+        );
+
+        this.state.ripeData.bind("selected_part", part => {
+            if (this.state.selectedPartData === part) return;
+            this.setState({ selectedPartData: part }, () => this.props.onUpdateSelectedPart(part));
+        });
+
+        this.state.ripeData.bind("parts", parts => {
+            this.setState({ partsData: parts }, () => this.props.onUpdateParts(parts));
+        });
+
         this.configurator = this.state.ripeData.bindConfigurator(this.configuratorRef, {
             view: this.state.frameData ? this.state.frameData.split("-")[0] : null,
             position: this.state.frameData ? this.state.frameData.split("-")[1] : null,
@@ -178,11 +203,6 @@ export class RipeConfigurator extends Component {
             animation: this.props.animation,
             useMasks: this.props.useMasks,
             sensitivity: this.props.sensitivity
-        });
-
-        this.state.ripeData.bind("selected_part", part => {
-            if (this.state.selectedPartData === part) return;
-            this.setState({ selectedPartData: part }, () => this.props.onUpdateSelectedPart(part));
         });
 
         this.configurator.bind("highlighted_part", part => {
@@ -208,14 +228,14 @@ export class RipeConfigurator extends Component {
         this._resize(this.props.size);
     }
 
-    componentDidUpdate(prevProps) {
+    async componentDidUpdate(prevProps) {
         if (prevProps.size !== this.props.size) {
             this._resize(this.props.size);
         }
         if (prevProps.frame !== this.props.frame) {
             this._changeFrame(this.props.frame, prevProps.frame);
         }
-        if (JSON.stringify(prevProps.parts) !== JSON.stringify(this.props.parts)) {
+        if (!this._equalParts(prevProps.parts, this.props.parts)) {
             this._updateParts(this.props.parts);
         }
         if (prevProps.selectedPart !== this.props.selectedPart) {
@@ -228,47 +248,13 @@ export class RipeConfigurator extends Component {
             if (!this.configurator) return;
             this._updateUseMasks(this.props.useMasks);
         }
-        this._updateConfiguration(this.props, prevProps);
-        this._updateConfigurator(this.props, prevProps);
+        await this._updateConfiguration(this.props, prevProps);
+        await this._updateConfigurator(this.props, prevProps);
     }
 
     async componentWillUnmount() {
         if (this.configurator) await this.state.ripeData.unbindConfigurator(this.configurator);
         this.configurator = null;
-    }
-
-    async _configRipe() {
-        this.setState({ loading: true });
-
-        try {
-            await this.state.ripeData.config(this.props.brand, this.props.model, {
-                version: this.props.version,
-                parts: this.state.partsData
-            });
-        } catch (error) {
-            this.setState({ loading: false }, () => {
-                this.props.onLoaded();
-            });
-        }
-    }
-
-    /**
-     * Initializes RIPE instance if it does not exists and
-     * configures it with the given brand, model, version
-     * and parts. If a RIPE instance is provided, it will
-     * be used without further configuration.
-     */
-    async _setupRipe() {
-        if (!this.state.ripeData) {
-            this.setState({ ripeData: new Ripe() }, async () => await this._configRipe());
-        } else {
-            await this._configRipe();
-        }
-
-        // in case the global RIPE instance is not set then
-        // updates it with the current one
-        if (global.ripe) return;
-        global.ripe = this.state.ripeData;
     }
 
     /**
@@ -310,15 +296,6 @@ export class RipeConfigurator extends Component {
         this.configurator.resize(size);
     }
 
-    _updateParts(parts) {
-        this.setState(
-            {
-                partsData: parts
-            },
-            async () => await this._configRipe()
-        );
-    }
-
     _highlightPart(part, previousPart) {
         this.configurator.lowlight(previousPart);
         this.configurator.highlight(part);
@@ -329,40 +306,41 @@ export class RipeConfigurator extends Component {
         else this.configurator.disableMasks();
     }
 
-    _updateConfiguration(props, prevProps) {
+    _updateParts(parts) {
+        this.setState(
+            {
+                partsData: parts
+            },
+            async () => {
+                this.props.onUpdateParts(parts);
+                await this._configRipe();
+            }
+        );
+    }
+
+    async _updateConfiguration(props, prevProps) {
         if (
             prevProps.brand !== props.brand ||
             prevProps.model !== props.model ||
             prevProps.version !== props.version
         ) {
-            this.setState(
-                {
-                    partsData: null
-                },
-                async () => await this._configRipe()
-            );
+            await this._configRipe();
         }
     }
 
-    _updateConfigurator(props, prevProps) {
+    async _updateConfigurator(props, prevProps) {
         if (
             prevProps.sensitivity !== props.sensitivity ||
             prevProps.duration !== props.duration ||
             prevProps.animation !== props.animation ||
             prevProps.format !== props.format
         ) {
-            this.setState(
-                {
-                    partsData: null
-                },
-                async () =>
-                    await this.configurator.updateOptions({
-                        sensitivity: this.props.sensitivity,
-                        duration: this.props.duration,
-                        animation: this.props.animation,
-                        format: this.props.format
-                    })
-            );
+            await this.configurator.updateOptions({
+                sensitivity: this.props.sensitivity,
+                duration: this.props.duration,
+                animation: this.props.animation,
+                format: this.props.format
+            });
         }
     }
 

--- a/react/components/organisms/ripe-image/ripe-image.js
+++ b/react/components/organisms/ripe-image/ripe-image.js
@@ -201,8 +201,8 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
                 partsData: parts
             },
             async () => {
-                this.props.onUpdateParts(parts);
-                await this._configRipe();
+                await this.props.onUpdateParts(parts);
+                await this._setPartsRipe(parts);
             }
         );
     }

--- a/react/components/organisms/ripe-image/ripe-image.js
+++ b/react/components/organisms/ripe-image/ripe-image.js
@@ -152,6 +152,7 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
         );
 
         this.partsBind = this.state.ripeData.bind("parts", parts => {
+            if (this._equalParts(parts, this.state.partsData)) return;
             this.setState({ partsData: parts }, () => this.props.onUpdateParts(parts));
         });
 

--- a/react/components/organisms/ripe-price/ripe-price.js
+++ b/react/components/organisms/ripe-price/ripe-price.js
@@ -146,8 +146,8 @@ export class RipePrice extends mix(Component).with(LogicMixin, MoneyMixin) {
                 partsData: parts
             },
             async () => {
-                this.props.onUpdateParts(parts);
-                await this._configRipe();
+                await this.props.onUpdateParts(parts);
+                await this._setPartsRipe(parts);
             }
         );
     }

--- a/react/components/organisms/ripe-price/ripe-price.js
+++ b/react/components/organisms/ripe-price/ripe-price.js
@@ -114,6 +114,7 @@ export class RipePrice extends mix(Component).with(LogicMixin, MoneyMixin) {
         );
 
         this.state.ripeData.bind("parts", parts => {
+            if (this._equalParts(parts, this.state.partsData)) return;
             this.setState({ partsData: parts }, () => this.props.onUpdateParts(parts));
         });
 

--- a/react/mixins/index.js
+++ b/react/mixins/index.js
@@ -1,1 +1,2 @@
+export * from "./logic";
 export * from "./money";

--- a/react/mixins/logic.js
+++ b/react/mixins/logic.js
@@ -2,10 +2,6 @@ import { Ripe } from "ripe-sdk";
 
 export const LogicMixin = superclass =>
     class extends superclass {
-        async _setPartsRipe(parts) {
-            await this.state.ripeData.setParts(parts);
-        }
-
         /**
          * Initializes RIPE instance if it does not exists and
          * configures it with the given brand, model, version
@@ -39,6 +35,19 @@ export const LogicMixin = superclass =>
                     this.props.onLoaded();
                 });
             }
+        }
+
+        /**
+         * Runs a series of part changes as a transaction changing
+         * the current model's configuration.
+         *
+         * @param {Object} parts An object that associated the name of the
+         * part to be changed with an object containing both the material
+         * and the color for the part.
+         */
+
+        async _setPartsRipe(parts) {
+            await this.state.ripeData.setParts(parts);
         }
 
         _equalParts(first, second) {

--- a/react/mixins/logic.js
+++ b/react/mixins/logic.js
@@ -1,0 +1,81 @@
+import { Ripe } from "ripe-sdk";
+
+export const LogicMixin = superclass =>
+    class extends superclass {
+        async _configRipe() {
+            this.setState({ loading: true });
+
+            try {
+                await this.state.ripeData.config(this.props.brand, this.props.model, {
+                    version: this.props.version,
+                    parts: this.props.parts,
+                    currency: this.props.currency?.toUpperCase()
+                });
+            } catch (error) {
+                this.setState({ loading: false }, () => {
+                    this.props.onLoaded();
+                });
+            }
+        }
+
+        /**
+         * Initializes RIPE instance if it does not exists and
+         * configures it with the given brand, model, version
+         * and parts. If a RIPE instance is provided, it will
+         * be used without further configuration.
+         */
+        async _setupRipe() {
+            if (!this.state.ripeData) {
+                this.setState({ ripeData: new Ripe() }, async () => await this._configRipe());
+            } else {
+                await this._configRipe();
+            }
+
+            // in case the global RIPE instance is not set then
+            // updates it with the current one
+            if (global.ripe) return;
+            global.ripe = this.state.ripeData;
+        }
+
+        _equalParts(first, second) {
+            if (!first && !second) return true;
+            if (Boolean(first) !== Boolean(second)) {
+                return false;
+            }
+
+            if (!this._subsetCompare(first, second)) {
+                return false;
+            }
+
+            if (!this._subsetCompare(second, first)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        _subsetCompare(base, reference) {
+            for (const name of Object.keys(base)) {
+                // retrieves the part information for the current
+                // name in iteration for both the base and the
+                // reference set values (to be compared)
+                const partB = base[name];
+                const partR = reference[name];
+
+                // if for a certain base part the corresponding
+                // part does not exist in the reference then the
+                // reference is considered to be invalid
+                if (!partR) {
+                    return false;
+                }
+
+                // in case either the initials or the engraving is
+                // not matching then the subset is invalid
+                if (partB.material !== partR.material || partB.color !== partR.color) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    };

--- a/react/mixins/logic.js
+++ b/react/mixins/logic.js
@@ -2,20 +2,8 @@ import { Ripe } from "ripe-sdk";
 
 export const LogicMixin = superclass =>
     class extends superclass {
-        async _configRipe() {
-            this.setState({ loading: true });
-
-            try {
-                await this.state.ripeData.config(this.props.brand, this.props.model, {
-                    version: this.props.version,
-                    parts: this.props.parts,
-                    currency: this.props.currency ? this.props.currency.toUpperCase() : null
-                });
-            } catch (error) {
-                this.setState({ loading: false }, () => {
-                    this.props.onLoaded();
-                });
-            }
+        async _setPartsRipe(parts) {
+            await this.state.ripeData.setParts(parts);
         }
 
         /**
@@ -35,6 +23,22 @@ export const LogicMixin = superclass =>
             // updates it with the current one
             if (global.ripe) return;
             global.ripe = this.state.ripeData;
+        }
+
+        async _configRipe() {
+            this.setState({ loading: true });
+
+            try {
+                await this.state.ripeData.config(this.props.brand, this.props.model, {
+                    version: this.props.version,
+                    parts: this.props.parts,
+                    currency: this.props.currency ? this.props.currency.toUpperCase() : null
+                });
+            } catch (error) {
+                this.setState({ loading: false }, () => {
+                    this.props.onLoaded();
+                });
+            }
         }
 
         _equalParts(first, second) {

--- a/react/mixins/logic.js
+++ b/react/mixins/logic.js
@@ -9,7 +9,7 @@ export const LogicMixin = superclass =>
                 await this.state.ripeData.config(this.props.brand, this.props.model, {
                     version: this.props.version,
                     parts: this.props.parts,
-                    currency: this.props.currency?.toUpperCase()
+                    currency: this.props.currency ? this.props.currency.toUpperCase() : null
                 });
             } catch (error) {
                 this.setState({ loading: false }, () => {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | All components that receive `parts` as props now have bi-directionality, meaning that any change to the parts made in the SDK will be communicated to the component's parent. <br><br> Refactor made to the setup of Ripe SDK, with the same functions being moved to a mixin. |
| Animated GIF | -- |