### PR TITLE
feat: image twitch component

### DIFF
--- a/react/components/organisms/ripe-configurator/ripe-configurator.js
+++ b/react/components/organisms/ripe-configurator/ripe-configurator.js
@@ -199,16 +199,16 @@ export class RipeConfigurator extends mix(Component).with(LogicMixin) {
             this.setState({ loading: true }, () => this.props.onLoading());
         });
 
-        this.state.ripeData.bind("selected_part", part => {
+        this.onSelectedPartEvent = this.state.ripeData.bind("selected_part", part => {
             if (this.state.selectedPartData === part) return;
             this.setState({ selectedPartData: part }, () => this.props.onUpdateSelectedPart(part));
         });
 
-        this.configurator.bind("changed_frame", frame => {
+        this.onChangedFrame = this.configurator.bind("changed_frame", frame => {
             this.setState({ frameData: frame }, () => this.props.onUpdateFrame(frame));
         });
 
-        this.configurator.bind("loaded", () => {
+        this.onConfiguratorLoaded = this.configurator.bind("loaded", () => {
             const frame = `${this.configurator.view}-${this.configurator.position}`;
 
             this.setState({ frameData: frame, loading: false }, () => {
@@ -217,11 +217,11 @@ export class RipeConfigurator extends mix(Component).with(LogicMixin) {
             });
         });
 
-        this.configurator.bind("not_loaded", () => {
+        this.onConfiguratorNotLoaded = this.configurator.bind("not_loaded", () => {
             this.setState({ loading: false }, () => this.props.onLoaded());
         });
 
-        this.configurator.bind("highlighted_part", part => {
+        this.onHighlightedPart = this.configurator.bind("highlighted_part", part => {
             if (this.state.highlightedPartData === part) return;
             this.setState({ highlightedPartData: part }, () =>
                 this.props.onUpdateHighlightedPart(part)
@@ -253,6 +253,18 @@ export class RipeConfigurator extends mix(Component).with(LogicMixin) {
     }
 
     async componentWillUnmount() {
+        if (this.configurator && this.onHighlightedPart) {
+            this.configurator.unbind("highlighted_part", this.onHighlightedPart);
+        }
+        if (this.configurator && this.onConfiguratorNotLoaded) {
+            this.configurator.unbind("not_loaded", this.onConfiguratorNotLoaded);
+        }
+        if (this.configurator && this.onConfiguratorLoaded) {
+            this.configurator.unbind("loaded", this.onConfiguratorLoaded);
+        }
+        if (this.configurator && this.onChangedFrame) {
+            this.configurator.unbind("changed_frame", this.onChangedFrame);
+        }
         if (this.configurator) await this.state.ripeData.unbindConfigurator(this.configurator);
         if (this.onPreConfigEvent && this.state.ripeData) {
             this.state.ripeData.unbind("pre_config", this.onPreConfigEvent);

--- a/react/components/organisms/ripe-image/ripe-image.js
+++ b/react/components/organisms/ripe-image/ripe-image.js
@@ -439,7 +439,7 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
             curve: this.props.curve
         });
 
-        this.onImageError = this.image.bind("error", () => this.onError());
+        this.onImageError = this.image.bind("error", () => this._onError());
 
         // only updates if the SDK configuration is not empty
         if (this.state.ripeData.brand) {

--- a/react/components/organisms/ripe-image/ripe-image.js
+++ b/react/components/organisms/ripe-image/ripe-image.js
@@ -250,7 +250,11 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
             /**
              * Style to be applied to the image, used for zoom application.
              */
-            style: PropTypes.object
+            style: PropTypes.object,
+            /**
+             * Callback called when an error occurs while loading the image.
+             */
+            onError: PropTypes.func
         };
     }
 
@@ -308,7 +312,8 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
             offsets: null,
             curve: null,
             name: null,
-            style: {}
+            style: {},
+            onError: () => {}
         };
     }
 
@@ -434,6 +439,8 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
             curve: this.props.curve
         });
 
+        this.onImageError = this.image.bind("error", () => this.onError());
+
         // only updates if the SDK configuration is not empty
         if (this.state.ripeData.brand) {
             await this.image.update({
@@ -467,6 +474,7 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
     }
 
     async componentWillUnmount() {
+        if (this.image && this.onImageError) this.image.unbind("error", this.onImageError);
         if (this.image) await this.state.ripeData.unbindImage(this.image);
         this.image = null;
     }
@@ -585,6 +593,10 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
 
     _onLoaded() {
         this.setState({ loading: false }, () => this.props.onLoaded());
+    }
+
+    _onError() {
+        this.props.onError();
     }
 
     render() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-sdk-components-vue/pull/53 |
| Dependencies | -- |
| Decisions | Added missing event propagation on `error` in `ripe-image`. <br> Added missing unbinds for image and configurator events. |
| Animated GIF | -- |
