### PR TITLE
fix: bump ripe-sdk and fix ripe-image

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "prop-types": "^15.7.2",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "ripe-sdk": "^1.22.0",
+        "ripe-sdk": "^2.6.0",
         "yonius": "^0.5.7"
     },
     "devDependencies": {

--- a/react/components/organisms/ripe-image/ripe-image.js
+++ b/react/components/organisms/ripe-image/ripe-image.js
@@ -384,8 +384,42 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
     async componentDidMount() {
         this.props.onLoading();
 
+        if (this.state.ripeData) this.state.ripeData.bind("ready", this._setupImage)
+
         await this.setupRipe();
 
+        if (this.state.ripeData.loadedConfig) this._setupImage()
+    }
+
+    async componentDidUpdate(prevProps) {
+        await this._componentDidUpdate(prevProps);
+
+        if (!this.image) return;
+
+        if (prevProps.size !== this.props.size) {
+            this.setState({ loading: true });
+            this.image.resize(this.props.size);
+        }
+        if (prevProps.frame !== this.props.frame) {
+            this.setState({ loading: true });
+            this.image.setFrame(this.props.frame);
+        }
+        if (prevProps.showInitials !== this.props.showInitials) {
+            this.image.setShowInitials(this.props.showInitials);
+        }
+        if (prevProps.initialsBuilder !== this.props.initialsBuilder) {
+            this.image.setInitialsBuilder(this.props.initialsBuilder);
+        }
+        await this._updateImage(this.props, prevProps);
+    }
+
+    async componentWillUnmount() {
+        if (this.image && this.onImageError) this.image.unbind("error", this.onImageError);
+        if (this.image) await this.state.ripeData.unbindImage(this.image);
+        this.image = null;
+    }
+
+    _setupImage = async () => {
         this.image = this.state.ripeData.bindImage(this.imageRef, {
             frame: this.props.frame,
             size: this.props.size || undefined,
@@ -449,34 +483,6 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
                 initialsExtra: this.state.initialsExtraData || {}
             });
         }
-    }
-
-    async componentDidUpdate(prevProps) {
-        await this._componentDidUpdate(prevProps);
-
-        if (!this.image) return;
-
-        if (prevProps.size !== this.props.size) {
-            this.setState({ loading: true });
-            this.image.resize(this.props.size);
-        }
-        if (prevProps.frame !== this.props.frame) {
-            this.setState({ loading: true });
-            this.image.setFrame(this.props.frame);
-        }
-        if (prevProps.showInitials !== this.props.showInitials) {
-            this.image.setShowInitials(this.props.showInitials);
-        }
-        if (prevProps.initialsBuilder !== this.props.initialsBuilder) {
-            this.image.setInitialsBuilder(this.props.initialsBuilder);
-        }
-        await this._updateImage(this.props, prevProps);
-    }
-
-    async componentWillUnmount() {
-        if (this.image && this.onImageError) this.image.unbind("error", this.onImageError);
-        if (this.image) await this.state.ripeData.unbindImage(this.image);
-        this.image = null;
     }
 
     /**

--- a/react/components/organisms/ripe-image/ripe-image.js
+++ b/react/components/organisms/ripe-image/ripe-image.js
@@ -384,11 +384,11 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
     async componentDidMount() {
         this.props.onLoading();
 
-        if (this.state.ripeData) this.state.ripeData.bind("ready", this._setupImage)
+        if (this.state.ripeData) this.state.ripeData.bind("ready", this._setupImage);
 
         await this.setupRipe();
 
-        if (this.state.ripeData.loadedConfig) this._setupImage()
+        if (this.state.ripeData.loadedConfig) this._setupImage();
     }
 
     async componentDidUpdate(prevProps) {
@@ -483,7 +483,7 @@ export class RipeImage extends mix(Component).with(LogicMixin) {
                 initialsExtra: this.state.initialsExtraData || {}
             });
         }
-    }
+    };
 
     /**
      * Verifies if values changed an, if so, updates

--- a/react/test/components/ripe-pickers/ripe-pickers.test.js
+++ b/react/test/components/ripe-pickers/ripe-pickers.test.js
@@ -94,17 +94,6 @@ const _choices = {
 describe("RipePickers", function() {
     this.timeout(TEST_TIMEOUT);
 
-    // it("should instantiate the component", () => {
-    //     const onLoading = sinon.fake();
-    //     const ripe = new Ripe("dummy", "cube", {
-    //         version: 52
-    //     });
-
-    //     mount(<RipePickers ripe={ripe} onLoading={onLoading} />);
-
-    //     assert.strictEqual(onLoading.called, true);
-    // });
-
     it("should instantiate the component", async () => {
         const ripeInstance = new Ripe("dummy", "cube", {
             version: 52,
@@ -118,7 +107,7 @@ describe("RipePickers", function() {
 
         await component.instance().componentDidMount();
         await ripeInstance.isReady();
-        await ripeInstance.trigger("choices", _choices);
+        ripeInstance.setChoices(_choices);
 
         component.update();
 
@@ -142,7 +131,7 @@ describe("RipePickers", function() {
 
         await component.instance().componentDidMount();
         await ripeInstance.isReady();
-        await ripeInstance.trigger("choices", _choices);
+        ripeInstance.setChoices(_choices);
 
         component.update();
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Changes related to SDK initial, which requires the loaded config. This resulted in an error when construction `ripe-image` when the SDK was not yet ready. Similar to https://github.com/ripe-tech/ripe-sdk-components-vue/pull/57 but the errors were in the console. |
| Dependencies | -- |
| Decisions | - Bumped SDK version to most recent<br>- Fixed problem of loadedConfig is null by only binding the image after the SDK is ready. |
| Animated GIF | -- |
